### PR TITLE
Add `feeAmount` arg when creating a Cabal

### DIFF
--- a/apps/contracts/README.md
+++ b/apps/contracts/README.md
@@ -31,5 +31,7 @@ pnpm test
 
 | Contract        | Network      | Address                                    |
 | --------------- | ------------ | ------------------------------------------ |
-| CabalFactory    | Base Sepolia | 0xcaba15de77BC1a93556347030D299995dFE777c6 |
+| CabalFactory    | Base         | 0xcaba192BB6D2b5fCeC3808Ecc7bBAbf1392e0Ae9 |
+| CabalFactory    | Base Sepolia | 0xcaba192BB6D2b5fCeC3808Ecc7bBAbf1392e0Ae9 |
+| RelayerRegistry | Base         | 0xcaba1cC2590F1f72041e01346e2e7307065A9108 |
 | RelayerRegistry | Base Sepolia | 0xcaba1cC2590F1f72041e01346e2e7307065A9108 |

--- a/apps/contracts/scripts/deploy-cabal.ts
+++ b/apps/contracts/scripts/deploy-cabal.ts
@@ -21,7 +21,7 @@ async function main() {
     encodedArgs,
     contractName,
     caseSensitive: true,
-    startingIteration: 5882000,
+    startingIteration: 20521000,
   })
 
   console.log(`Deployed ${contractName} to ${address}`)

--- a/apps/contracts/src/CabalFactory.sol
+++ b/apps/contracts/src/CabalFactory.sol
@@ -4,6 +4,18 @@ pragma solidity 0.8.23;
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {Cabal} from "./Cabal.sol";
 
+///////////////////////////////////////////////////////////////////////
+//                                                                   //
+//      .g8"""bgd     db      `7MM"""Yp,      db      `7MMF'         //
+//    .dP'     `M    ;MM:       MM    Yb     ;MM:       MM           //
+//    dM'       `   ,V^MM.      MM    dP    ,V^MM.      MM           //
+//    MM           ,M  `MM      MM"""bg.   ,M  `MM      MM           //
+//    MM.          AbmmmqMA     MM    `Y   AbmmmqMA     MM      ,    //
+//    `Mb.     ,' A'     VML    MM    ,9  A'     VML    MM     ,M    //
+//      `"bmmmd'.AMA.   .AMMA..JMMmmmd9 .AMA.   .AMMA..JMMmmmmMMM    //
+//                                                                   //
+///////////////////////////////////////////////////////////////////////
+
 /// @notice A factory for creating Cabal contracts.
 contract CabalFactory {
     /// @notice The address of the RelayerRegistry contract.

--- a/apps/contracts/src/CabalFactory.sol
+++ b/apps/contracts/src/CabalFactory.sol
@@ -32,9 +32,9 @@ contract CabalFactory {
     }
 
     /// @notice Creates a new Cabal contract.
-    function createCabal(uint256 identityCommitment) external returns (address) {
+    function createCabal(uint256 identityCommitment, uint256 feeAmount) external returns (address) {
         address cabal = Clones.clone(implementation);
-        Cabal(payable(cabal)).initialize(identityCommitment);
+        Cabal(payable(cabal)).initialize(identityCommitment, feeAmount);
         emit CabalCreated(address(cabal));
         return cabal;
     }

--- a/apps/contracts/test/Cabal.test.ts
+++ b/apps/contracts/test/Cabal.test.ts
@@ -27,7 +27,7 @@ const deploy = async () => {
   const cabalFactory = await hre.viem.deployContract('CabalFactory', [
     zeroAddress,
   ])
-  await cabalFactory.write.createCabal([identity1.commitment, 0n])
+  await cabalFactory.write.createCabal([identity1.commitment, 100n])
   const events = await cabalFactory.getEvents.CabalCreated()
   const cabal = await hre.viem.getContractAt('Cabal', events[0].args.cabal!)
 
@@ -35,7 +35,7 @@ const deploy = async () => {
   const [walletClient] = await hre.viem.getWalletClients()
   await walletClient.sendTransaction({
     to: cabal.address,
-    value: BigInt(2000),
+    value: BigInt(20000),
   })
 
   return { cabal }
@@ -56,7 +56,7 @@ describe('Cabal', function () {
       expect(chainId).to.equal(BigInt(hardhat.id))
     })
 
-    it('should let relayers execute signed calls', async function () {
+    it('should let relayers execute signed calls and pay out the fee', async function () {
       const { cabal } = await loadFixture(deploy)
 
       const abiEncodedCalldata = encodeAbiParameters(
@@ -79,6 +79,12 @@ describe('Cabal', function () {
       const message = BigInt(keccak256(abiEncodedCalldata)) // Hashed calldata
       const proof = await generateProof(identity1, group, message, scope)
 
+      const account1BalanceBefore = await (
+        await hre.viem.getPublicClient()
+      ).getBalance({
+        address: account1,
+      })
+
       const sendEtherTx = cabal.write.execute(
         [
           account2, // to
@@ -90,6 +96,25 @@ describe('Cabal', function () {
       )
 
       await expect(sendEtherTx).to.be.fulfilled
+
+      const account1BalanceAfter = await (
+        await hre.viem.getPublicClient()
+      ).getBalance({
+        address: account1,
+      })
+
+      const { cumulativeGasUsed, effectiveGasPrice } = await (
+        await hre.viem.getPublicClient()
+      ).getTransactionReceipt({
+        hash: await sendEtherTx,
+      })
+
+      const ethSubtractedFromGasFee = cumulativeGasUsed * effectiveGasPrice
+
+      const fee = await cabal.read.feeAmount()
+      expect(account1BalanceAfter).to.be.equal(
+        account1BalanceBefore + fee - ethSubtractedFromGasFee
+      )
     })
 
     it('should let a member add new members', async function () {

--- a/apps/contracts/test/Cabal.test.ts
+++ b/apps/contracts/test/Cabal.test.ts
@@ -27,7 +27,7 @@ const deploy = async () => {
   const cabalFactory = await hre.viem.deployContract('CabalFactory', [
     zeroAddress,
   ])
-  await cabalFactory.write.createCabal([identity1.commitment])
+  await cabalFactory.write.createCabal([identity1.commitment, 0n])
   const events = await cabalFactory.getEvents.CabalCreated()
   const cabal = await hre.viem.getContractAt('Cabal', events[0].args.cabal!)
 


### PR DESCRIPTION
Requires new deployments and I don't feel like mining a new CREATE2 salt right now so keeping in a separate branch

Todo:
- [x] Add test to make sure relayers are getting paid the expected fee